### PR TITLE
Add py2app setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+APP = ['GUI/GuiMain.py']
+DATA_FILES = ['icon/icon.icns']
+OPTIONS = {
+    'argv_emulation': True,
+    'iconfile': 'icon/icon.icns',
+}
+
+setup(
+    app=APP,
+    name='Demucs-GUI',
+    data_files=DATA_FILES,
+    options={'py2app': OPTIONS},
+    setup_requires=['py2app'],
+)


### PR DESCRIPTION
## Summary
- provide `setup.py` using py2app so macOS users can generate an app bundle

## Testing
- `python -m py_compile setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6873bbbdaad4832e963caee26f403200